### PR TITLE
[Update]会員側：マイページ、編集、退会機能

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,10 +1,33 @@
 class Public::CustomersController < ApplicationController
   def show
+    @customer = current_customer
   end
 
   def edit
+    @customer = current_customer
+  end
+
+  def update
+    @customer = current_customer
+     if @customer.update(customer_params)
+      redirect_to customers_my_page_path
+    else
+      render "edit"
+    end
   end
 
   def cancel
+    @customer = current_customer
   end
+
+  def unsubscribe
+    @customer = current_customer
+    @customer.update(is_deleted: true)
+    redirect_to root_path
+  end
+
+  def customer_params
+    params.require(:customer).permit(:first_name, :last_name, :first_name_kana, :last_name_kana, :postal_code, :address, :telephone_number, :email)
+  end
+
 end

--- a/app/views/public/customers/cancel.html.erb
+++ b/app/views/public/customers/cancel.html.erb
@@ -1,2 +1,15 @@
-<h1>Public::Customers#cancel</h1>
-<p>Find me in app/views/public/customers/cancel.html.erb</p>
+<div class="col-sm-8 mx-auto my-5">
+  <h3 class="text-center py-3 my-4">本当に退会しますか？</h3>
+    <div class="text-center">
+      <p>
+        退会すると、会員登録情報や</br>
+        これまでの購入履歴が閲覧できなくなります。</br>
+        退会する場合は、「退会する」をクリックしてください。
+      </p>
+    </div>
+
+    <div class="text-center">
+      <%= link_to "退会しない", customers_my_page_path, class: "btn btn-primary col-sm-2 p-2 mt-3" %>
+      <%= link_to "退会する", customers_my_page_cancel_path, method: :patch, class: "btn btn-danger col-sm-2 offset-sm-1 p-2 mt-3" %>
+    </div>
+</div>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,2 +1,44 @@
-<h1>Public::Customers#edit</h1>
-<p>Find me in app/views/public/customers/edit.html.erb</p>
+<h3 class="bg-light py-3 my-4 offset-md-1">会員情報編集</h3>
+<div class="col-sm-12 mx-auto">
+  <%= form_with model: @customer, url: customer_path(@customer.id), class: 'form-horizontal', local: true do |f| %>
+    <%= render "public/customers/shared/error_messages", resource: @customer %>
+
+    <div class="field form-group row">
+      <%= f.label :"氏名", class: "col-sm-3 control-label" %>
+      <%= f.text_field :first_name, autofocus: true, class: "col-sm-2" %>
+      <%= f.text_field :last_name, autofocus: true, class: "col-sm-2 ml-5" %>
+    </div>
+
+    <div class="field form-group row">
+      <%= f.label :"フリガナ", class: "col-sm-3 control-label" %>
+      <%= f.text_field :first_name_kana, autofocus: true, class: "col-sm-2" %>
+      <%= f.text_field :last_name_kana, autofocus: true, class: "col-sm-2 ml-5" %>
+    </div>
+
+    <div class="field form-group row">
+      <%= f.label :"郵便番号", class: "col-sm-3 control-label" %>
+      <%= f.text_field :postal_code, autofocus: true, class: "col-sm-2" %>
+    </div>
+
+    <div class="field form-group row">
+      <%= f.label :"住所", class: "col-sm-3 control-label" %>
+      <%= f.text_field :address, autofocus: true, class: "col-sm-6" %>
+    </div>
+
+    <div class="field form-group row">
+      <%= f.label :"電話番号", class: "col-sm-3 control-label" %>
+      <%= f.text_field :telephone_number, autofocus: true, class: "col-sm-2" %>
+    </div>
+
+    <div class="field form-group row">
+      <%= f.label :"メールアドレス", class: "col-sm-3 control-label" %>
+      <%= f.text_field :email, autofocus: true, class: "col-sm-2" %>
+    </div>
+
+    <div class="field form-group row">
+      <%= f.submit "編集内容を保存", class: "btn btn-success col-sm-3 offset-sm-3 p-2 mt-3" %>
+      <%= link_to "退会する", customers_my_page_cancel_path, class: "btn btn-danger col-sm-2 offset-sm-1 p-2 mt-3" %>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -1,2 +1,47 @@
-<h1>Public::Customers#show</h1>
-<p>Find me in app/views/public/customers/show.html.erb</p>
+<div class="col-md-6">
+  <h4 class="bg-light p-3 my-4 d-inline-block offset-md-3">マイページ</h4>
+  <div class="mb-3">
+    <h4 class=" d-inline">登録情報</h4>
+    <%= link_to "編集する", customers_my_page_edit_path, class:"btn btn-success ml-5" %>
+  </div>
+
+  <table class="table table-bordered">
+    <tr>
+      <td class="table-active">氏名</td>
+      <td><%= "#{@customer.first_name}　#{@customer.last_name}" %></td>
+    </tr>
+    <tr>
+      <td class="table-active">カナ</td>
+      <td><%= "#{@customer.first_name_kana}　#{@customer.last_name_kana}" %></td>
+    </tr>
+    <tr>
+      <td class="table-active">郵便番号</td>
+      <td><%= @customer.postal_code %></td>
+    </tr>
+    <tr>
+      <td class="table-active">住所</td>
+      <td><%= @customer.address %></td>
+    </tr>
+    <tr>
+      <td class="table-active">電話番号</td>
+      <td><%= @customer.telephone_number %></td>
+    </tr>
+    <tr>
+      <td class="table-active">メールアドレス</td>
+      <td><%= @customer.email %></td>
+    </tr>
+
+  </table>
+
+  <div class="mt-4">
+    <h5 class=" d-inline col-1">配送先　</h5>
+    <%= link_to "一覧を見る", addresses_path, class:"btn btn-primary col-md-3" %>
+  </div>
+
+  <div class="mt-4">
+    <h5 class=" d-inline col-1">注文履歴</h5>
+    <%= link_to "一覧を見る", orders_path, class:"btn btn-primary col-md-3" %>
+  </div>
+
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,11 @@ Rails.application.routes.draw do
   resources :products, only: [:index, :show], controller: "public/products"
   resources :cart_products, only: [:index, :update, :destroy], controller: "public/cart_products"
   delete "cart_products" => "public/cart_products#destroy_all"
-  resources :customers, only: [:edit, :update], controller: "public/customers" #showを削除
+  resources :customers, only: [:update], controller: "public/customers" #showを削除
   get "customers/my_page" => "public/customers#show"                           #showアクションのurlをmy_pageに変更
-  get "customers" => "public/customers#cancel"
-  patch "customers" => "public/customers#unsubscribe"
+  get "customers/my_page/edit" => "public/customers#edit"
+  get "customers/my_page/cancel" => "public/customers#cancel"
+  patch "customers/my_page/cancel" => "public/customers#unsubscribe"
   resources :orders, only: [:index, :show, :new, :create], controller: "public/orders"
   post "orders" => "public/orders#confirm"
   get "orders" => "public/orders#complete"


### PR DESCRIPTION
## 実装機能
会員側
* マイページ詳細
* マイページ編集
* マイページ退会
* route.rb変更
→マイページ編集の際、/cutomers/editのURLだと
　deviseのパスワード変更画面に遷移してしまうため、
　mypage関連のURLを変更しました。
　変更後のURLは詳細設計書を参照。