### PR TITLE
[Update] payjp実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 .DS_Store
+/.env

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -62,7 +62,20 @@
   <%= f.hidden_field :shipping_cost, value: @order.shipping_cost %>
   <%= f.hidden_field :total_payment, value: @order.total_payment %>
   <%= f.hidden_field :payment_method, value: @order.payment_method %>
-  <%= f.submit "注文を確定する", class: "btn btn-success m-4 p-2 block-right" %>
+  <% if @order.payment_method == "銀行振込" %>
+    <%= f.submit "注文を確定する", class: "btn btn-success m-4 p-2 block-right" %>
+  <% elsif @order.payment_method == "クレジットカード" %>
+    <script
+      type="text/javascript"
+      src="https://checkout.pay.jp/"
+      class="payjp-button"
+      data-key="<%= ENV["PAYJP_PUBLIC_KEY"] %>"
+      data-text="カード情報を入力する"
+      data-submit-text="注文を確定する">
+      <% f.submit %>
+    </script>
+  <% end %>
+
 <% end %>
 
 


### PR DESCRIPTION
## 実装機能
### 会員側
* payjp実装
※チェックアウトで実装しています。カード情報入力フォームを自作する場合は、カスタム機能で実装する必要あり
* 環境変数はコミットしていないので、各自でテストする場合は、```./nagano-cake/.env```に、APIキーを入れてください。